### PR TITLE
Remove gcloud indicator from starship prompt

### DIFF
--- a/private_dot_config/starship.toml
+++ b/private_dot_config/starship.toml
@@ -148,7 +148,7 @@ ssh_only = false
 style = "green"
 
 [java]
-symbol = " "
+symbol = " "
 style = "red"
 
 [aws]
@@ -158,4 +158,7 @@ disabled = true
 disabled = true
 
 [golang]
-symbol = " "
+symbol = " "
+
+[gcloud]
+disabled = true


### PR DESCRIPTION
Disable the `gcloud` module in Starship to remove the "on ☁️" segment from the prompt.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ff35448-fec9-4e64-a8c3-d20a16cc8f4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ff35448-fec9-4e64-a8c3-d20a16cc8f4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

